### PR TITLE
added m and t keyboard-press functionality

### DIFF
--- a/client/src/components/Calendar.tsx
+++ b/client/src/components/Calendar.tsx
@@ -96,24 +96,54 @@ function Calendar(this: any, props: Props) {
       localStorage.setItem("mode", "dark");
     }
   };
-
   const configureKeyDownEvents = () => {
     window.addEventListener("keydown", (e) => {
-      const btn1 = document.getElementById("e-tbr-btn_1");
-      const btn0 = document.getElementById("e-tbr-btn_0");
+      const scheduleObj: any = (document.querySelector(".e-schedule") as any).ej2_instances[0];
+      const btnBackwards = document.getElementById("e-tbr-btn_0");
+      const btnForward = document.getElementById("e-tbr-btn_1");
+      const btnToday = document.getElementById("e-tbr-btn_3");
+      const btnDay = document.getElementById("e-tbr-btn_4");
+      const btnWeek = document.getElementById("e-tbr-btn_5");
+      const btnMonth = document.getElementById("e-tbr-btn_6");
+      const btnAgenda = document.getElementById("e-tbr-btn_7");
 
       switch (e.key) {
         case "Right":
         case "ArrowRight":
           e.preventDefault();
-          btn1?.click();
-          btn1?.blur();
+          btnForward?.click();
+          btnForward?.blur();
           break;
         case "Left":
         case "ArrowLeft":
           e.preventDefault();
-          btn0?.click();
-          btn0?.blur();
+          btnBackwards?.click();
+          btnBackwards?.blur();
+          break;
+        case "m":
+          switch (scheduleObj.currentView) {
+            case 'Day':
+              btnWeek?.click();
+              btnWeek?.blur();
+              break;
+            case 'WorkWeek':
+              btnMonth?.click();
+              btnMonth?.blur();
+              break;
+            case 'Month':
+              btnAgenda?.click();
+              btnAgenda?.blur();
+              break;
+            case 'Agenda':
+              btnDay?.click();
+              btnDay?.blur();
+              break;
+            default:
+              break;
+          }
+        case 't':
+          btnToday?.click();
+          btnToday?.blur();
           break;
         default:
           break;


### PR DESCRIPTION

- by clicking 'm' the application switches between the schedule views. 'mode' => 'm'
- by clicking 't' it also resets to today. 'today' => 't'


also felt free to rename btn0 and btn1


![image](https://github.com/MaRcR11/ba-schedule/assets/97552289/dbf0014f-7153-4e69-9cca-f2fbb6a5e35b)
[Alt Text](https://www.youtube.com/watch?v=Vk4KK-gh0FM)