### PR TITLE
added focus to changeLoginMode - Links

### DIFF
--- a/client/src/components/GeneralLogin.tsx
+++ b/client/src/components/GeneralLogin.tsx
@@ -98,7 +98,16 @@ function GeneralLogin(props: GeneralLoginProps) {
               </div>
               <div className="has-text-centered">
                 <p className="is-size-7">
-                  <a onClick={props.changeLoginMode} className="has-text-link">
+                  <a
+                    tabIndex={0}
+                    onClick={props.changeLoginMode}
+                    className="has-text-link"
+                    onKeyDown={(event) => {
+                      if (event.key === "Enter") {
+                        event.preventDefault();
+                        props.changeLoginMode();
+                      }
+                    }}>
                     User Login
                   </a>
                 </p>

--- a/client/src/components/UserLogin.tsx
+++ b/client/src/components/UserLogin.tsx
@@ -110,7 +110,16 @@ function UserLogin(props: UserLoginProps) {
               </div>
               <div className="has-text-centered">
                 <p className="is-size-7">
-                  <a onClick={props.changeLoginMode} className="has-text-link">
+                  <a
+                    tabIndex={0}
+                    onClick={props.changeLoginMode}
+                    className="has-text-link"
+                    onKeyDown={(event) => {
+                      if (event.key === "Enter") {
+                        event.preventDefault();
+                        props.changeLoginMode();
+                      }
+                    }}>
                     General Login
                   </a>{" "}
                   -&nbsp;


### PR DESCRIPTION
Previously when tabbing through the two different login sites the user wasn't able to focus on the "General Login" and "User Login" achnor tags and therefor not being able to change login modes by pressing enter on the link.

Fixed it by giving the two different anchor tags a `tabindex` of 0 and also adding a `onKeyDown` event which fires a `props.changeLoginMode()` when the pressed Key is "Enter"
<p>
<img src="https://github.com/MaRcR11/ba-schedule/assets/97552289/ea1416e1-814b-42fc-8063-be60d8515f24" width=400/>
<img src="https://github.com/MaRcR11/ba-schedule/assets/97552289/df84bb87-fe81-499b-9e9a-28850e8ae706" width=400/>
</p>